### PR TITLE
fix: remove invalid VuePress 2 config options

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -57,6 +57,8 @@ export default defineUserConfig({
 
   theme: defaultTheme({
     logo: '/logo.png',
+    lastUpdated: false,
+    contributors: false,
     
     locales: {
       '/': {
@@ -141,7 +143,5 @@ export default defineUserConfig({
         ],
       },
     },
-
-    sidebar: 'auto',
   }),
 })


### PR DESCRIPTION
- Disable lastUpdated and contributors display on pages
- Remove invalid sidebar: 'auto' option (not supported in VuePress 2)