### PR TITLE
fix: correct QR code image paths in localized pages

### DIFF
--- a/docs/de/others/README.md
+++ b/docs/de/others/README.md
@@ -21,7 +21,7 @@ _Pocket Gallery_ ist eine eigenständig entwickelte und betriebene Pokémon Pok�
                 Wir danken Ihnen von Herzen für Ihre Unterstützung!
 
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />

--- a/docs/es/others/README.md
+++ b/docs/es/others/README.md
@@ -21,7 +21,7 @@ _Pocket Gallery_ es un software de Pokédex Pokémon desarrollado y operado de m
                 ¡Agradecemos sinceramente a todos por su apoyo!
 
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />

--- a/docs/fr/others/README.md
+++ b/docs/fr/others/README.md
@@ -21,7 +21,7 @@ _Pocket Gallery_ est un logiciel de Pokédex Pokémon développé et exploité i
                Nous vous remercions sincèrement pour votre soutien!
                
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />

--- a/docs/it/others/README.md
+++ b/docs/it/others/README.md
@@ -22,7 +22,7 @@ _Pocket Gallery_ è un software Pokédex Pokémon sviluppato e gestito in modo i
                 Grazie di cuore a tutti per il vostro sostegno! 
                 
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />

--- a/docs/ja-jp/others/README.md
+++ b/docs/ja-jp/others/README.md
@@ -25,7 +25,7 @@ _ポケット・ギャラリー_ は、独自に開発・運営されている�
                皆様のサポートに心より感謝申し上げます！
 
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />

--- a/docs/ko/others/README.md
+++ b/docs/ko/others/README.md
@@ -22,7 +22,7 @@ _포켓 갤러리_ 는 독립적으로 개발하고 운영하는 포켓몬 도�
                 진심으로 여러분의 지원에 감사드립니다!
                 
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />

--- a/docs/zh-hans/others/README.md
+++ b/docs/zh-hans/others/README.md
@@ -23,7 +23,7 @@ _破壳萌图鉴_ 是一款独立开发、运营的宝可梦图鉴软件。本�
                衷心感谢大家的支持！
 
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />

--- a/docs/zh-hant/others/README.md
+++ b/docs/zh-hant/others/README.md
@@ -23,7 +23,7 @@ _破殼萌圖鑑_ 是一款獨立開發、運營的寶可夢圖鑑軟件。本�
                 衷心感謝大家的支持！
                 
 ### Alipay
-<img src="..//qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
+<img src="/qr_alipay.jpg" width = "300" alt="Alipay QR Code" align=center />
 
 ### WeChat
-<img src="..//qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />
+<img src="/qr_wechat.jpg" width = "300" alt="WeChat QR Code" align=center />


### PR DESCRIPTION
Changed relative paths to absolute paths for QR code images in all localized others pages (de, es, fr, it, ja-jp, ko, zh-hans, zh-hant)